### PR TITLE
Add RS-safe patch shuffling

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ This system includes **five layers** of anti-detection defenses:
 4. **Transform-Domain Embedding (DCT)**  
    Optionally embeds payload into mid-band JPEG-DCT coefficients for added stealth.
 
-5. **Classifier-Resistant Statistical Masking**  
-   Uses RS-safe and visually invariant patch masking to reduce detectability by ML models.
+5. **Classifier-Resistant Statistical Masking**
+   RS-safe, patch-based shuffling is applied at high stealth level to preserve global statistics while disrupting local correlations.
 
 ---
 
@@ -54,7 +54,9 @@ cargo run --release --   extract   --stego stego.png   --output extracted_secret
 - `--redundancy 3` — set bit redundancy factor (default: 3)
 - `--domain lsb|lsb-match|dct` — select embedding domain
 - `--stealth high|medium|low` — control aggressiveness of classifier masking
-- `--progress` — show progress bar and estimated time
+ - `--progress` — show progress bar and estimated time
+
+When `--stealth high` is chosen, additional patch shuffling preserves image statistics while further confusing RS analysis.
 
 ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use clap::{Parser, Subcommand, ValueEnum};
 use image::{DynamicImage, GenericImageView, RgbaImage, Luma};
 use imageproc::gradients::sobel_gradient_map;
 use rand::{Rng, SeedableRng};
+use rand::seq::SliceRandom;
 use rand::distributions::{WeightedIndex, Distribution};
 use rand::rngs::StdRng;
 use sha2::{Sha256, Sha512, Digest};
@@ -420,12 +421,45 @@ fn mask_medium(img: &mut RgbaImage, rng: &mut StdRng) {
     *img = blurred;
 }
 
+fn mask_rs_safe(img: &mut RgbaImage, rng: &mut StdRng) {
+    let (width, height) = img.dimensions();
+    let block = 4;
+    for by in (0..height).step_by(block as usize) {
+        for bx in (0..width).step_by(block as usize) {
+            let mut patch = Vec::new();
+            for y in 0..block {
+                for x in 0..block {
+                    let nx = bx + x;
+                    let ny = by + y;
+                    if nx < width && ny < height {
+                        patch.push(*img.get_pixel(nx, ny));
+                    }
+                }
+            }
+            patch.shuffle(rng);
+            let mut iter = patch.into_iter();
+            for y in 0..block {
+                for x in 0..block {
+                    let nx = bx + x;
+                    let ny = by + y;
+                    if nx < width && ny < height {
+                        if let Some(px) = iter.next() {
+                            img.put_pixel(nx, ny, px);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn mask_high(img: &mut RgbaImage, rng: &mut StdRng) {
     for _ in 0..2 {
         mask_low(img, rng);
         let blurred = image::imageops::blur(img, 1.0);
         *img = blurred;
     }
+    mask_rs_safe(img, rng);
 }
 
 fn mask_image(img: &mut RgbaImage, level: StealthLevel, password: &str) {


### PR DESCRIPTION
## Summary
- implement `mask_rs_safe` patch-based shuffling for high stealth
- integrate into `mask_high`
- document new stealth behaviour

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68441365a6348323962733ffa02d9651