### PR TITLE
Graceful error when CRC length exceeds bit buffer

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -141,6 +141,9 @@ fn add_crc_and_len(bits: &[u8]) -> Vec<u8> {
 fn check_crc_and_len(bits: &[u8]) -> Option<Vec<u8>> {
     let length = bits_to_int(&bits[..32]);
     let crc_expected = bits_to_int(&bits[32..64]);
+    if 64 + length > bits.len() {
+        return None;
+    }
     let data = &bits[64..64 + length];
     let mut hasher = Crc32Hasher::new();
     hasher.update(&bits_to_bytes(data));


### PR DESCRIPTION
## Summary
- prevent panics in `check_crc_and_len` if the embedded length field is corrupt

## Testing
- `cargo build --release`
- `cargo test`
- `cargo run --release -- embed --cover bird.jpeg --secret secret.txt --output stego.png --password password`
- `cargo run --release -- extract --stego stego.png --output recovered.txt --password password` (fails gracefully)

------
https://chatgpt.com/codex/tasks/task_e_68441c074a148323968282cf815073a3