### PR TITLE
Prevent out-of-bounds panic in CRC length check

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -139,9 +139,12 @@ fn add_crc_and_len(bits: &[u8]) -> Vec<u8> {
 }
 
 fn check_crc_and_len(bits: &[u8]) -> Option<Vec<u8>> {
+    if bits.len() < 64 {
+        return None;
+    }
     let length = bits_to_int(&bits[..32]);
     let crc_expected = bits_to_int(&bits[32..64]);
-    if 64 + length > bits.len() {
+    if length > bits.len().saturating_sub(64) {
         return None;
     }
     let data = &bits[64..64 + length];


### PR DESCRIPTION
## Summary
- ensure `check_crc_and_len` validates bit slice length before slicing

## Testing
- `cargo build`


------
https://chatgpt.com/codex/tasks/task_e_6844201397108323b6e031c6c5482d2d